### PR TITLE
Export orphan Num instances from base-orphans

### DIFF
--- a/music-score.cabal
+++ b/music-score.cabal
@@ -22,6 +22,7 @@ source-repository head
   
 library
     build-depends:      base                    >= 4 && < 5,
+                        base-orphans            >= 0.1 && < 0.4,
                         aeson                   >= 0.7.0.6 && < 1,
                         lens                    >= 4.6      && < 4.7,
                         process                 >= 1.2 && < 1.3,

--- a/src/Data/Semigroup/Instances.hs
+++ b/src/Data/Semigroup/Instances.hs
@@ -1,5 +1,4 @@
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE DeriveFunctor #-}
@@ -16,10 +15,6 @@ import Music.Dynamics.Literal
 
 -- TODO move these to semigroups and music-pitch-literal
 
-#if !MIN_VERSION_base(4,7,0)
-deriving instance Num a => Num (Sum a)
-#endif
-
 deriving instance Real a => Real (Sum a)
 deriving instance Fractional a => Fractional (Sum a)
 deriving instance AdditiveGroup a => AdditiveGroup (Sum a)
@@ -33,10 +28,6 @@ instance AffineSpace a => AffineSpace (Sum a) where
   Sum p .-. Sum q = Sum (p .-. q)
   Sum p .+^ Sum v = Sum (p .+^ v)
 
-
-#if !MIN_VERSION_base(4,7,0)
-deriving instance Num a => Num (Product a)
-#endif
 
 deriving instance Real a => Real (Product a)
 deriving instance Fractional a => Fractional (Product a)


### PR DESCRIPTION
Currently, `music-score` defines orphan `Num` instances for `Sum` and `Product`. However, there is at least one other package that exports these same orphan instances ([`Agda`](https://github.com/agda/agda/blob/7a55ad5c31ca928ca927c93f67948af243c76aa2/src/full/Agda/Syntax/Internal.hs#L942-944)), possibly others. If these packages were used together on an old version of GHC, it could lead to instance conflicts.

To help mitigate this possibility, this pull request imports these instances from the `base-orphans` library (which exports backported instances introduced in later versions of `base`, including the aforementioned ones). This way, we can keep all of these orphan instances in one package so that `Agda`, `music-score`, etc. can coexist.