### PR TITLE
Remove orphan instances provided by base-orphans-0.5

### DIFF
--- a/music-score.cabal
+++ b/music-score.cabal
@@ -12,25 +12,25 @@ build-type:             Custom
 cabal-version:          >= 1.10
 data-files:             data/ly_big_score.ily
 
-description: 
+description:
     Musical time structure, voices, tracks and scores.
-    
+
     This library is part of the Music Suite, see <http://music-suite.github.io>.
 
 source-repository head
   type:               git
   location:           git://github.com/music-suite/music-score.git
-  
+
 library
     build-depends:      base                    >= 4 && < 5,
-                        base-orphans            >= 0.1 && < 1,
+                        base-orphans            >= 0.5 && < 1,
                         bytestring              >= 0.10.4.0 && < 1,
                         aeson                   >= 0.7.0.6 && < 1,
                         lens                    >= 4.11     && < 5,
                         process                 >= 1.2 && < 1.3,
                         split                   >= 0.2.2    && < 1,
                         containers,
-                        nats,          
+                        nats,
                         average                 >= 0.6.1    && < 1,
                         semigroups              >= 0.13.0.1 && < 1,
                         comonad                 >= 4.2.2 && < 5,
@@ -151,5 +151,5 @@ library
                         TypeOperators,
                         ViewPatterns,
                         OverloadedStrings
-    
+
     ghc-options:        -fno-warn-typed-holes

--- a/src/Data/PairMonad.hs
+++ b/src/Data/PairMonad.hs
@@ -15,12 +15,14 @@ import Control.Lens()
 
 import Data.Monoid
 import Data.Foldable
+import Data.Orphans ()
 import Data.Traversable
 
 -- Equivalent to the Monad Writer instance.
-instance Monoid o => Monad ((,) o) where
-  return      = pure
-  (o,a) >>= f = (o `mappend` o', a') where (o',a') = f a
+-- The following is provided by Data.Orphans
+-- instance Monoid o => Monad ((,) o) where
+--   return      = pure
+--   (o,a) >>= f = (o `mappend` o', a') where (o',a') = f a
 
 -- #ifndef __HAS_LENS__
 -- deriving instance Foldable ((,) o)

--- a/src/Data/Semigroup/Instances.hs
+++ b/src/Data/Semigroup/Instances.hs
@@ -6,6 +6,7 @@
 
 module Data.Semigroup.Instances () where
 
+import Data.Orphans ()
 import Data.Semigroup
 import Data.VectorSpace hiding (Sum)
 import Data.AffineSpace
@@ -48,16 +49,6 @@ deriving instance IsDynamics a => IsDynamics (Sum a)
 deriving instance IsDynamics a => IsDynamics (Product a)
 deriving instance IsPitch a => IsPitch (Sum a)
 deriving instance IsPitch a => IsPitch (Product a)
-
-deriving instance Functor Product
-instance Applicative Product where
-  pure = Product
-  Product f <*> Product x = Product (f x)
-
-deriving instance Functor Sum
-instance Applicative Sum where
-  pure = Sum
-  Sum f <*> Sum x = Sum (f x)
 
 
 {-


### PR DESCRIPTION
In a similar vein as #337, this commit consolidates some orphan instances that were introduced in GHC 8.0/`base-4.9` using `base-orphans-0.5`. Specifically:

* The `Functor`/`Applicative` instances for `Sum`/`Product`
* The `Monad` instance for `(,)`